### PR TITLE
Preliminary support for dealing with dynamic data

### DIFF
--- a/assistant-ingestion-sink/pom.xml
+++ b/assistant-ingestion-sink/pom.xml
@@ -104,6 +104,18 @@
       <artifactId>quarkus-container-image-jib</artifactId>
     </dependency>
 
+
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-hibernate-orm-panache</artifactId>
+    </dependency>
+
+    <!-- JDBC driver dependencies -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-jdbc-h2</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
@@ -126,6 +138,14 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven-compiler-plugin.version}</version>
+        <configuration>
+          <parameters>true</parameters>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/assistant-ingestion-sink/src/main/java/org/apache/camel/assistant/data/ingestion/sink/CollectionProcessor.java
+++ b/assistant-ingestion-sink/src/main/java/org/apache/camel/assistant/data/ingestion/sink/CollectionProcessor.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.assistant.data.ingestion.sink;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.LongAdder;
+
+import io.qdrant.client.PointIdFactory;
+import io.qdrant.client.grpc.Points;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.Processor;
+import org.apache.camel.component.qdrant.Qdrant;
+import org.jboss.logging.Logger;
+
+public class CollectionProcessor implements Processor {
+    private static final LongAdder ADDER = new LongAdder();
+    private static final Logger LOG = Logger.getLogger(CollectionProcessor.class);
+
+    @Override
+    public void process(Exchange exchange) throws Exception {
+        Message message = exchange.getMessage();
+
+        final String body = exchange.getMessage().getBody(String.class);
+        if (body != null) {
+            Points.PointId id = message.getHeader(Qdrant.Headers.POINT_ID, Points.PointId.class);
+
+            if (id != null) {
+                LOG.infof("Processing message with ID: %s", id.getUuid());
+            } else {
+                id = PointIdFactory.id(UUID.randomUUID());
+                LOG.infof("Using the newly created ID: %s", id.getUuid());
+
+                message.setHeader(Qdrant.Headers.POINT_ID, id);
+            }
+        } else {
+            LOG.warnf("Payload body: %s = %s", exchange.getMessage().getBody());
+            LOG.warnf("Processing body of type: %s", exchange.getMessage().getBody().getClass());
+        }
+    }
+}

--- a/assistant-ingestion-sink/src/main/java/org/apache/camel/assistant/data/ingestion/sink/entities/Mapping.java
+++ b/assistant-ingestion-sink/src/main/java/org/apache/camel/assistant/data/ingestion/sink/entities/Mapping.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.assistant.data.ingestion.sink.entities;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Table(name = "mapping")
+@Entity
+public class Mapping {
+    @Id
+    @GeneratedValue
+    public Long id;
+
+    @Column(name = "internal_id")
+    public String internalId;
+
+    @Column(name = "external_id")
+    public String externalId;
+
+    @Column(name = "external_source")
+    public String externalSource;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getInternalId() {
+        return internalId;
+    }
+
+    public void setInternalId(String internalId) {
+        this.internalId = internalId;
+    }
+
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public void setExternalId(String externalId) {
+        this.externalId = externalId;
+    }
+
+    public String getExternalSource() {
+        return externalSource;
+    }
+
+    public void setExternalSource(String externalSource) {
+        this.externalSource = externalSource;
+    }
+}

--- a/assistant-ingestion-sink/src/main/java/org/apache/camel/assistant/data/ingestion/sink/repository/MappingRepository.java
+++ b/assistant-ingestion-sink/src/main/java/org/apache/camel/assistant/data/ingestion/sink/repository/MappingRepository.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.assistant.data.ingestion.sink.repository;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import org.apache.camel.assistant.data.ingestion.sink.entities.Mapping;
+
+@ApplicationScoped
+public class MappingRepository implements PanacheRepository<Mapping> {
+
+    public Mapping findByInternalId(String internalId) {
+        return find("internalId", internalId).firstResult();
+    }
+
+    public Mapping findByExternal(String externalId, String externalSource) {
+        return find("externalId = ?1 and externalSource = ?2", externalId, externalSource).firstResult();
+    }
+}

--- a/assistant-ingestion-sink/src/main/resources/application.properties
+++ b/assistant-ingestion-sink/src/main/resources/application.properties
@@ -1,2 +1,14 @@
 quarkus.banner.enabled = false
 quarkus.devservices.enabled = false
+
+%prod.quarkus.datasource.db-kind = h2
+%prod.quarkus.datasource.jdbc.url = jdbc:h2:~/.camel-assistant/sink
+
+# drop and create the database at startup (use `update` to only update the schema)
+quarkus.hibernate-orm.database.generation = drop-and-create
+quarkus.hibernate-orm.log.sql=true
+quarkus.hibernate-orm.sql-load-script=import.sql
+quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect
+
+%dev.quarkus.datasource.db-kind = h2
+%dev.quarkus.datasource.jdbc.url = jdbc:h2:~/.camel-assistant/sink-dev

--- a/assistant-ingestion-sink/src/main/resources/import.sql
+++ b/assistant-ingestion-sink/src/main/resources/import.sql
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+CREATE TABLE IF NOT EXISTS `mapping`
+(
+    `id` BIGINT PRIMARY KEY AUTO_INCREMENT,
+    `internal_id` VARCHAR NOT NULL UNIQUE,
+    `external_id` VARCHAR NOT NULL,
+    `external_source` VARCHAR NOT NULL
+);
+
+

--- a/assistant-ingestion-sink/src/main/resources/kamelets/langchain-embeddings-action.kamelet.yaml
+++ b/assistant-ingestion-sink/src/main/resources/kamelets/langchain-embeddings-action.kamelet.yaml
@@ -24,9 +24,14 @@ spec:
     - "camel:kamelet"
     - "camel:core"
   template:
+    beans:
+      - name: collectionProcessorBean
+        type: "#class:org.apache.camel.assistant.data.ingestion.sink.CollectionProcessor"
     from:
       uri: kamelet:source
       steps:
+        - process:
+            ref: "{{collectionProcessorBean}}"
         - to: "langchain-embeddings:{{embeddingId}}"
         - transform:
             toType: qdrant:embeddings

--- a/assistant-ingestion-sink/src/main/resources/kamelets/langchain-embeddings-action.kamelet.yaml
+++ b/assistant-ingestion-sink/src/main/resources/kamelets/langchain-embeddings-action.kamelet.yaml
@@ -24,14 +24,11 @@ spec:
     - "camel:kamelet"
     - "camel:core"
   template:
-    beans:
-      - name: collectionProcessorBean
-        type: "#class:org.apache.camel.assistant.data.ingestion.sink.CollectionProcessor"
     from:
       uri: kamelet:source
       steps:
         - process:
-            ref: "{{collectionProcessorBean}}"
+            ref: "collectionProcessorBean"
         - to: "langchain-embeddings:{{embeddingId}}"
         - transform:
             toType: qdrant:embeddings

--- a/assistant-ingestion-sources/plain-text-source/README.md
+++ b/assistant-ingestion-sources/plain-text-source/README.md
@@ -1,0 +1,27 @@
+Types of Data:
+
+* Static: data that doesn't change often. Facts.
+* Dynamic: data that can change quickly (i.e.: transient information that can change over time)
+
+For example: 
+
+* Static data: Apache Camel 4.4.0 was released on February 2024. 
+* Dynamic data: The latest Apache Camel version is 4.4.0 and was released on February 2024. 
+
+On the examples above, note how the dynamic data can change over time (i.e.: when the community releases a new major version, that will be the latest version)
+
+Insert static data: 
+
+```shell
+curl -X POST http://localhost:8083/api/consume/static -H "Content-Type: text/plain" -d 'Apache Camel is 4.4.0 was released on February 2024'
+```
+
+* The path format is: `api/consume/{externalSourceName}/{externalSourceId}`
+
+Insert dynamic data: 
+
+```shell
+curl -X POST http://localhost:8083/api/consume/dynamic/cli.org/1 -H "Content-Type: text/plain" -d 'The latest version of Apache Camel is 4.5.1 and it was released on March 2024'
+```
+
+* The path format is: `api/consume/{externalSourceName}/{externalSourceId}`

--- a/assistant-ingestion-sources/plain-text-source/src/main/java/org/apache/camel/assistant/data/ingestion/source/plaintext/PlainTextRoute.java
+++ b/assistant-ingestion-sources/plain-text-source/src/main/java/org/apache/camel/assistant/data/ingestion/source/plaintext/PlainTextRoute.java
@@ -19,22 +19,26 @@ package org.apache.camel.assistant.data.ingestion.source.plaintext;
 
 import org.apache.camel.builder.RouteBuilder;
 
-
 public class PlainTextRoute extends RouteBuilder {
 
     @Override
     public void configure() throws Exception {
         rest("/api")
                 .get("/hello").to("direct:hello")
-                .post("/consume")
-                .to("direct:consume");
+                .post("/consume/static").to("direct:consumeStatic")
+                .post("/consume/dynamic/{source}/{id}").to("direct:consumeDynamic");
 
         from("direct:hello")
                 .routeId("source-web-hello")
                 .transform().constant("Hello World");
 
-        from("direct:consume")
-                .routeId("source-consume-route")
+        from("direct:consumeDynamic")
+                .routeId("source-consume-dynamic-route")
+                .setHeader("dynamic", constant("true"))
+                .to("kafka:ingestion?brokers={{bootstrap.servers}}");
+
+        from("direct:consumeStatic")
+                .routeId("source-consume-static-route")
                 .to("kafka:ingestion?brokers={{bootstrap.servers}}");
     }
 }


### PR DESCRIPTION
When you use this, the behavior should be similar to this: 

1. Load some dynamic data: 

```shell
curl -X POST http://localhost:8083/api/consume/dynamic/cli.org/1 -H "Content-Type: text/plain" -d 'The latest version of Apache Camel is 4.4.0 and it was released in February 2024'
```

2. Ask the system for information: 

```shell
curl -X POST http://localhost:8080/api/hello -H "Content-Type: text/plain" -d 'What is the latest Apache Camel version?'
Apache Camel 4.4.0 is the latest version, which was released in February 2024.
```

3. Update the system with new information that supersedes the old one: 

```shell
curl -X POST http://localhost:8083/api/consume/dynamic/cli.org/1 -H "Content-Type: text/plain" -d 'The latest version of Apache Camel is 4.5.0 and it was released on March 2024'
```

4. Ask again the system for information:

```shell
curl -X POST http://localhost:8080/api/hello -H "Content-Type: text/plain" -d 'What is the latest Apache Camel version?'
Apache Camel 4.5.0 is the latest version, which was released in March 2024.
``` 

Obs.: you may need to wait a few seconds between steps 3 and 4. Also, depending on the model utilized, it may *still* hallucinate a bit.